### PR TITLE
feat(seo): optimize /contact + Loi 25 compliance on legal pages

### DIFF
--- a/app/components/contact-card.tsx
+++ b/app/components/contact-card.tsx
@@ -23,21 +23,12 @@ export default function ContactCard() {
             commence.
           </p>
 
-          <div className="mt-10 flex justify-center gap-2 flex-col-reverse lg:flex-row">
-            <a
-              href="https://calendly.com/contact-pierrebarbe/30min"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="btn w-full min-w-[250px] rounded-full font-semibold lg:w-auto"
-            >
-              Réserver une consultation
-            </a>
-
+          <div className="mt-10 flex justify-center">
             <a
               href="/contact"
               className="btn w-full min-w-[250px] rounded-full font-semibold lg:w-auto"
             >
-              Envoyer un message
+              Réserver ma consultation gratuite
             </a>
           </div>
         </div>

--- a/app/routes/contact.tsx
+++ b/app/routes/contact.tsx
@@ -1,56 +1,128 @@
 import ContactForm from "~/components/contact-form";
-import { Clock, Mail, Phone } from "lucide-react";
+import { Clock, Mail, MapPin, Phone } from "lucide-react";
 import { useToast } from "~/context/toast-context";
 import Breadcrumbs from "~/components/breadcrumbs";
 import JsonLd from "~/components/json-ld";
 
 import type { Route } from "./+types/contact";
 
+const SITE = "https://pierrebarbe.ca";
+
 const contactSchema = {
   "@context": "https://schema.org",
   "@graph": [
     {
       "@type": ["WebPage", "ContactPage"],
-      "@id": "https://pierrebarbe.ca/contact#webpage",
-      url: "https://pierrebarbe.ca/contact",
-      name: "Contact et devis de site web à Montréal",
-      description: "Une question ou un projet ? Écris‑moi ou réserve ta consultation gratuite de 30 min pour booster performance et éco‑conception de ton site.",
+      "@id": `${SITE}/contact#webpage`,
+      url: `${SITE}/contact`,
+      name: "Contact et devis site web à Montréal",
+      description:
+        "Demande un devis site web ou réserve ta consultation gratuite de 30 min. Développeur freelance à Montréal — Laval, Longueuil, partout au Québec.",
       inLanguage: "fr-CA",
-      isPartOf: { "@id": "https://pierrebarbe.ca/#website" },
-      breadcrumb: { "@id": "https://pierrebarbe.ca/contact#breadcrumb" },
+      isPartOf: { "@id": `${SITE}/#website` },
+      breadcrumb: { "@id": `${SITE}/contact#breadcrumb` },
+      about: { "@id": `${SITE}/#business` },
+      mainEntity: { "@id": `${SITE}/#business` },
     },
     {
       "@type": "BreadcrumbList",
-      "@id": "https://pierrebarbe.ca/contact#breadcrumb",
+      "@id": `${SITE}/contact#breadcrumb`,
       itemListElement: [
-        { "@type": "ListItem", position: 1, name: "Accueil", item: "https://pierrebarbe.ca/" },
+        { "@type": "ListItem", position: 1, name: "Accueil", item: `${SITE}/` },
         { "@type": "ListItem", position: 2, name: "Contact" },
       ],
+    },
+    {
+      "@type": "Person",
+      "@id": `${SITE}/#person`,
+      name: "Pierre Barbé",
+      url: `${SITE}/about`,
+      email: "contact@pierrebarbe.ca",
+      telephone: "+1-438-448-8408",
+      jobTitle: "Développeur Web Freelance",
+      address: {
+        "@type": "PostalAddress",
+        addressLocality: "Montréal",
+        addressRegion: "QC",
+        addressCountry: "CA",
+      },
+      sameAs: [
+        "https://www.linkedin.com/in/pierre-barb%C3%A9/",
+        "https://github.com/pierrebre",
+        "https://twitter.com/PierreBarbe",
+      ],
+    },
+    {
+      "@type": ["LocalBusiness", "ProfessionalService"],
+      "@id": `${SITE}/#business`,
+      name: "Pierre Barbé — Développeur Web Freelance",
+      url: SITE,
+      telephone: "+1-438-448-8408",
+      email: "contact@pierrebarbe.ca",
+      priceRange: "$$",
+      image: `${SITE}/images/pb-og-image.jpg`,
+      address: {
+        "@type": "PostalAddress",
+        addressLocality: "Montréal",
+        addressRegion: "QC",
+        addressCountry: "CA",
+      },
+      geo: {
+        "@type": "GeoCoordinates",
+        latitude: "45.5017",
+        longitude: "-73.5673",
+      },
+      areaServed: [
+        { "@type": "City", name: "Montréal" },
+        { "@type": "City", name: "Laval" },
+        { "@type": "City", name: "Longueuil" },
+        { "@type": "State", name: "Québec" },
+        { "@type": "Country", name: "Canada" },
+      ],
+      openingHoursSpecification: {
+        "@type": "OpeningHoursSpecification",
+        dayOfWeek: ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
+        opens: "09:00",
+        closes: "18:00",
+      },
+      contactPoint: {
+        "@type": "ContactPoint",
+        telephone: "+1-438-448-8408",
+        email: "contact@pierrebarbe.ca",
+        contactType: "Customer Service",
+        areaServed: "CA",
+        availableLanguage: ["fr-CA", "en"],
+      },
+      sameAs: [
+        "https://www.linkedin.com/in/pierre-barb%C3%A9/",
+        "https://github.com/pierrebre",
+      ],
+      founder: { "@id": `${SITE}/#person` },
     },
   ],
 };
 
 export function meta({}: Route.MetaArgs) {
-  const url = "https://pierrebarbe.ca/contact";
-  const image = "https://pierrebarbe.ca/images/pb-og-image.jpg";
+  const url = `${SITE}/contact`;
+  const image = `${SITE}/images/pb-og-image.jpg`;
 
   return [
-    { title: "Contact et devis de site web à Montréal" },
+    { title: "Contact & devis site web à Montréal — Pierre Barbé" },
     { name: "robots", content: "index, follow, max-image-preview:large, max-snippet:-1" },
     { tagName: "link", rel: "canonical", href: url },
     {
       name: "description",
       content:
-        "Une question ou un projet ? Écris‑moi ou réserve ta consultation gratuite de 30 min pour booster performance et éco‑conception de ton site.",
+        "Demande un devis site web ou réserve ta consultation gratuite 30 min. Développeur freelance à Montréal, Laval, Longueuil & Québec. Réponse sous 24 h.",
     },
     {
       property: "og:title",
-      content: "Contact et devis de site web à Montréal",
+      content: "Contact & devis site web à Montréal — Pierre Barbé",
     },
     {
       property: "og:description",
       content:
-        "Réserve ta consultation gratuite ou envoie‑moi un message. Réponse en moins de 24 h.",
+        "Devis site web gratuit ou consultation 30 min. Montréal, Laval, Longueuil & Québec. Réponse sous 24 h.",
     },
     { property: "og:url", content: url },
     { property: "og:image", content: image },
@@ -61,8 +133,12 @@ export function meta({}: Route.MetaArgs) {
     { property: "og:site_name", content: "Pierre Barbé" },
     { property: "og:locale", content: "fr_CA" },
     { name: "twitter:card", content: "summary_large_image" },
-    { name: "twitter:title", content: "Contact et devis de site web à Montréal" },
-    { name: "twitter:description", content: "Réserve ta consultation gratuite ou envoie‑moi un message. Réponse en moins de 24 h." },
+    { name: "twitter:title", content: "Contact & devis site web à Montréal — Pierre Barbé" },
+    {
+      name: "twitter:description",
+      content:
+        "Devis site web gratuit ou consultation 30 min. Montréal, Laval, Longueuil & Québec.",
+    },
     { name: "twitter:image", content: image },
   ];
 }
@@ -83,6 +159,7 @@ export default function Contact() {
   return (
     <div className="bg-base-100 font-urbanist mx-auto max-w-7xl">
       <JsonLd data={contactSchema} />
+
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 pt-8">
         <Breadcrumbs
           items={[
@@ -92,73 +169,98 @@ export default function Contact() {
         />
       </div>
 
-      <section className="py-24">
+      <section className="py-20">
         <div className="container mx-auto px-6 text-center">
-          <h1 className="text-4xl font-bold md:text-5xl">Parlons de ton projet</h1>
+          <h1 className="text-4xl font-bold md:text-5xl">
+            Devis site web &amp; consultation gratuite — Montréal
+          </h1>
 
           <div className="mt-6 flex items-center justify-center gap-4">
             <div className="bg-primary h-px w-16" />
-            <span className="text-primary">Première consultation gratuite — 30 min</span>
+            <span className="text-primary">Consultation 30 min offerte — réponse sous 24 h</span>
             <div className="bg-primary h-px w-16" />
           </div>
 
-          <p className="text-base-content/80 mt-6 text-lg md:text-xl text-center">
-            On se parle 30 minutes. Tu m'expliques ton projet, je te donne mes
-            premières recommandations. Aucun engagement, aucune vente forcée.
-            <br />
-            <br />
-            Je travaille avec des entreprises locales à Montréal, Laval,
-            Longueuil et partout au Québec — en français comme en anglais.
+          <p className="text-base-content/80 mt-6 text-lg md:text-xl text-center max-w-3xl mx-auto">
+            Développeur web freelance à Montréal, je conçois des sites rapides,
+            bien référencés et éco-conçus pour les PME du Québec. Parle-moi de
+            ton projet de création ou refonte — je te réponds sous 24 h avec un
+            devis clair, sans engagement ni vente forcée.
           </p>
         </div>
       </section>
 
-      <div className="container mx-auto px-6 py-20">
+      <div className="container mx-auto px-6 py-12">
         <div className="grid gap-12 md:grid-cols-2">
           <div className="space-y-8">
             <h2 className="card-title text-2xl">Coordonnées</h2>
 
-            <div className="mt-6 space-y-6">
+            <dl className="mt-6 space-y-6">
               <div className="flex items-start gap-4">
-                <Phone className="text-primary mt-1 h-6 w-6" />
+                <Phone className="text-primary mt-1 h-6 w-6 shrink-0" aria-hidden="true" />
                 <div>
-                  <h3 className="text-lg font-medium">Téléphone</h3>
-                  <p className="text-base-content/80 mt-1">
-                    +1&nbsp;(438)&nbsp;448-8408
+                  <dt className="text-lg font-medium">Téléphone</dt>
+                  <dd className="text-base-content/80 mt-1">
+                    <a
+                      href="tel:+14384488408"
+                      className="link link-hover"
+                      aria-label="Appeler le +1 438 448 8408"
+                    >
+                      +1&nbsp;(438)&nbsp;448-8408
+                    </a>
                     <br />
-                    Réponse rapide (FR/EN)
-                  </p>
+                    <span className="text-sm">Réponse rapide (FR/EN)</span>
+                  </dd>
                 </div>
               </div>
 
               <div className="flex items-start gap-4">
-                <Mail className="text-primary mt-1 h-6 w-6" />
+                <Mail className="text-primary mt-1 h-6 w-6 shrink-0" aria-hidden="true" />
                 <div>
-                  <h3 className="text-lg font-medium">Courriel</h3>
-                  <p className="text-base-content/80 mt-1">
-                    contact@pierrebarbe.ca
-                  </p>
+                  <dt className="text-lg font-medium">Courriel</dt>
+                  <dd className="text-base-content/80 mt-1">
+                    <a
+                      href="mailto:contact@pierrebarbe.ca"
+                      className="link link-hover"
+                    >
+                      contact@pierrebarbe.ca
+                    </a>
+                  </dd>
                 </div>
               </div>
 
               <div className="flex items-start gap-4">
-                <Clock className="text-primary mt-1 h-6 w-6" />
+                <Clock className="text-primary mt-1 h-6 w-6 shrink-0" aria-hidden="true" />
                 <div>
-                  <h3 className="text-lg font-medium">Disponibilités</h3>
-                  <p className="text-base-content/80 mt-1">
-                    Lundi – Vendredi : 9 h – 18 h (heure de Montréal)
-                  </p>
+                  <dt className="text-lg font-medium">Disponibilités</dt>
+                  <dd className="text-base-content/80 mt-1">
+                    Lundi – Vendredi : 9&nbsp;h – 18&nbsp;h (heure de Montréal)
+                  </dd>
                 </div>
               </div>
-            </div>
+
+              <div className="flex items-start gap-4">
+                <MapPin className="text-primary mt-1 h-6 w-6 shrink-0" aria-hidden="true" />
+                <div>
+                  <dt className="text-lg font-medium">Zones servies</dt>
+                  <dd className="text-base-content/80 mt-1">
+                    Montréal, Laval, Longueuil, Rive-Sud, Rive-Nord
+                    <br />
+                    <span className="text-sm">
+                      Et partout au Québec en télétravail — FR/EN.
+                    </span>
+                  </dd>
+                </div>
+              </div>
+            </dl>
           </div>
 
           <div className="card bg-base-100 border-base-content/10 border">
             <div className="card-body">
-              <h2 className="card-title text-2xl">Un projet ? Une question?</h2>
+              <h2 className="card-title text-2xl">Un projet ? Une question ?</h2>
               <p className="text-base-content/80 mb-4">
-                Décris‑moi ton besoin ; je reviendrai vers toi rapidement avec
-                les prochaines étapes.
+                Décris-moi ton besoin&nbsp;: je reviens vers toi rapidement avec
+                les prochaines étapes et un devis clair.
               </p>
 
               <ContactForm onSubmitResult={handleFormSubmitResult} />

--- a/app/routes/legal-notice.tsx
+++ b/app/routes/legal-notice.tsx
@@ -1,35 +1,81 @@
 import Breadcrumbs from "~/components/breadcrumbs";
+import JsonLd from "~/components/json-ld";
 import type { Route } from "./+types/legal-notice";
 
+const SITE = "https://pierrebarbe.ca";
+const URL = `${SITE}/mentions-legales`;
+const DATE_MODIFIED = "2026-04-16";
+const DATE_PUBLISHED = "2025-06-03";
+
+const legalSchema = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebPage",
+      "@id": `${URL}#webpage`,
+      url: URL,
+      name: "Mentions légales",
+      description:
+        "Mentions légales du site pierrebarbe.ca : éditeur, hébergement, propriété intellectuelle, droit applicable et limitation de responsabilité.",
+      inLanguage: "fr-CA",
+      isPartOf: { "@id": `${SITE}/#website` },
+      breadcrumb: { "@id": `${URL}#breadcrumb` },
+      about: { "@id": `${SITE}/#business` },
+      dateModified: DATE_MODIFIED,
+      datePublished: DATE_PUBLISHED,
+    },
+    {
+      "@type": "BreadcrumbList",
+      "@id": `${URL}#breadcrumb`,
+      itemListElement: [
+        { "@type": "ListItem", position: 1, name: "Accueil", item: `${SITE}/` },
+        { "@type": "ListItem", position: 2, name: "Mentions légales" },
+      ],
+    },
+  ],
+};
+
 export function meta({}: Route.MetaArgs) {
-  const url = "https://pierrebarbe.ca/mentions-legales";
-  const image = "https://pierrebarbe.ca/images/pb-og-image.jpg";
+  const image = `${SITE}/images/pb-og-image.jpg`;
 
   return [
-    { title: "Mentions légales | Pierre Barbé" },
-    { name: "description", content: "Mentions légales, informations éditeur et hébergement du site pierrebarbe.ca." },
+    { title: "Mentions légales | Pierre Barbé" },
+    {
+      name: "description",
+      content:
+        "Mentions légales du site pierrebarbe.ca : éditeur, hébergement, propriété intellectuelle, droit applicable.",
+    },
     { name: "robots", content: "noindex, follow" },
-    { tagName: "link", rel: "canonical", href: url },
+    { tagName: "link", rel: "canonical", href: URL },
+    { property: "og:title", content: "Mentions légales" },
     {
-      property: "og:title",
-      content: "Mentions légales",
+      property: "og:description",
+      content:
+        "Mentions légales du site pierrebarbe.ca — éditeur, hébergement, droit applicable.",
     },
-    {
-      property: "og:site_name",
-      content: "Pierre Barbé",
-    },
-    { property: "og:url", content: url },
+    { property: "og:site_name", content: "Pierre Barbé" },
+    { property: "og:locale", content: "fr_CA" },
+    { property: "og:url", content: URL },
     { property: "og:image", content: image },
     { property: "og:image:width", content: "1200" },
     { property: "og:image:height", content: "630" },
     { property: "og:image:type", content: "image/jpeg" },
     { property: "og:type", content: "website" },
+    { name: "twitter:card", content: "summary_large_image" },
+    { name: "twitter:title", content: "Mentions légales | Pierre Barbé" },
+    {
+      name: "twitter:description",
+      content: "Mentions légales du site pierrebarbe.ca.",
+    },
+    { name: "twitter:image", content: image },
   ];
 }
 
 export default function LegalNotice() {
   return (
     <div>
+      <JsonLd data={legalSchema} />
+
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 pt-8">
         <Breadcrumbs
           items={[
@@ -41,59 +87,115 @@ export default function LegalNotice() {
 
       <section className="mx-auto max-w-4xl px-6 py-12">
         <h1 className="text-3xl font-bold mb-6">Mentions légales</h1>
-      <p className="mb-4 text-sm text-gray-500">
-        Dernière mise à jour : 3 juin 2025
-      </p>
+        <p className="mb-4 text-sm text-base-content/60">
+          Dernière mise à jour&nbsp;:{" "}
+          <time dateTime={DATE_MODIFIED}>16 avril 2026</time>
+        </p>
 
-      <h2 className="text-xl font-semibold mt-6 mb-2">👤 Éditeur du site</h2>
-      <p className="mb-4">
-        Ce site est édité par :<br />
-        <strong>Pierre Barbé</strong>
-        <br />
-        Développeur web freelance
-        <br />
-        Montréal, Québec (Canada)
-        <br />
-        <a
-          href="mailto:contact@pierrebarbe.ca"
-          className="text-primary underline"
-        >
-          contact@pierrebarbe.ca
-        </a>
-      </p>
+        <h2 className="text-xl font-semibold mt-6 mb-2">Éditeur du site</h2>
+        <p className="mb-4">
+          Ce site est édité par&nbsp;:<br />
+          <strong>Pierre Barbé</strong>
+          <br />
+          Développeur web freelance
+          <br />
+          Montréal, Québec (Canada)
+          <br />
+          <a
+            href="mailto:contact@pierrebarbe.ca"
+            className="text-primary underline"
+          >
+            contact@pierrebarbe.ca
+          </a>
+        </p>
 
-      <h2 className="text-xl font-semibold mt-6 mb-2">🆔 Enregistrement</h2>
-      <p className="mb-4">
-        Travailleur autonome opérant sous son nom légal.
-        <br />
-        Non assujetti à l’immatriculation au Registraire des entreprises du Québec.
-      </p>
+        <h2 className="text-xl font-semibold mt-6 mb-2">Enregistrement</h2>
+        <p className="mb-4">
+          Travailleur autonome opérant sous son nom légal.
+          <br />
+          Non assujetti à l&apos;immatriculation au Registraire des entreprises du
+          Québec.
+        </p>
 
-      <h2 className="text-xl font-semibold mt-6 mb-2">💻 Hébergement</h2>
-      <p className="mb-4">
-        Ce site est hébergé par :<br />
-        <strong>Vercel Inc.</strong>
-        <br />
-        340 S Lemon Ave #4133, Walnut, CA 91789, États-Unis
-        <br />
-        <a
-          href="https://vercel.com"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-primary underline"
-        >
-          https://vercel.com
-        </a>
-      </p>
+        <h2 className="text-xl font-semibold mt-6 mb-2">Hébergement</h2>
+        <p className="mb-4">
+          Ce site est hébergé par&nbsp;:<br />
+          <strong>Vercel Inc.</strong>
+          <br />
+          340 S Lemon Ave #4133, Walnut, CA 91789, États-Unis
+          <br />
+          <a
+            href="https://vercel.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary underline"
+          >
+            https://vercel.com
+          </a>
+        </p>
 
-      <h2 className="text-xl font-semibold mt-6 mb-2">
-        📜 Propriété intellectuelle
-      </h2>
-      <p className="mb-4">
-        Le contenu de ce site (textes, visuels, code) est protégé par le droit
-        d'auteur. Toute reproduction, même partielle, est interdite sans
-        autorisation écrite préalable.
-      </p>
+        <h2 className="text-xl font-semibold mt-6 mb-2">
+          Propriété intellectuelle
+        </h2>
+        <p className="mb-4">
+          Le contenu de ce site (textes, visuels, code) est protégé par le
+          droit d&apos;auteur. Toute reproduction, même partielle, est interdite
+          sans autorisation écrite préalable. Les icônes proviennent de{" "}
+          <a
+            href="https://lucide.dev"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary underline"
+          >
+            Lucide
+          </a>{" "}
+          (licence ISC).
+        </p>
+
+        <h2 className="text-xl font-semibold mt-6 mb-2">
+          Limitation de responsabilité
+        </h2>
+        <p className="mb-4">
+          Pierre Barbé s&apos;efforce de maintenir les informations de ce site
+          exactes et à jour, mais ne peut garantir l&apos;absence totale
+          d&apos;erreurs ou d&apos;omissions. L&apos;utilisateur reconnaît
+          utiliser ces informations sous sa seule responsabilité. En aucun cas
+          Pierre Barbé ne saurait être tenu responsable d&apos;un dommage direct
+          ou indirect résultant de l&apos;usage de ce site.
+        </p>
+
+        <h2 className="text-xl font-semibold mt-6 mb-2">
+          Liens vers d&apos;autres sites
+        </h2>
+        <p className="mb-4">
+          Ce site peut contenir des liens vers des sites tiers. Pierre Barbé ne
+          contrôle pas le contenu de ces sites et décline toute responsabilité
+          quant à leurs pratiques ou contenus.
+        </p>
+
+        <h2 className="text-xl font-semibold mt-6 mb-2">
+          Droit applicable et juridiction
+        </h2>
+        <p className="mb-4">
+          Les présentes mentions légales sont régies par les lois en vigueur au
+          Québec et au Canada. Tout litige relatif au présent site relèvera de
+          la compétence exclusive des tribunaux de Montréal (Québec, Canada).
+        </p>
+
+        <h2 className="text-xl font-semibold mt-6 mb-2">
+          Protection des données
+        </h2>
+        <p className="mb-4">
+          Pour toute question relative à la collecte et à l&apos;utilisation
+          des données personnelles, consulte la{" "}
+          <a
+            href="/politique-confidentialite"
+            className="text-primary underline"
+          >
+            politique de confidentialité
+          </a>
+          .
+        </p>
       </section>
     </div>
   );

--- a/app/routes/privacy-policy.tsx
+++ b/app/routes/privacy-policy.tsx
@@ -1,36 +1,81 @@
 import Breadcrumbs from "~/components/breadcrumbs";
+import JsonLd from "~/components/json-ld";
 import type { Route } from "./+types/privacy-policy";
 
+const SITE = "https://pierrebarbe.ca";
+const URL = `${SITE}/politique-confidentialite`;
+const DATE_MODIFIED = "2026-04-16";
+const DATE_PUBLISHED = "2025-06-03";
+
+const privacySchema = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebPage",
+      "@id": `${URL}#webpage`,
+      url: URL,
+      name: "Politique de confidentialité",
+      description:
+        "Politique de confidentialité conforme à la Loi 25 du Québec : données collectées, durée de conservation, transferts hors Québec, droits et recours.",
+      inLanguage: "fr-CA",
+      isPartOf: { "@id": `${SITE}/#website` },
+      breadcrumb: { "@id": `${URL}#breadcrumb` },
+      about: { "@id": `${SITE}/#business` },
+      dateModified: DATE_MODIFIED,
+      datePublished: DATE_PUBLISHED,
+    },
+    {
+      "@type": "BreadcrumbList",
+      "@id": `${URL}#breadcrumb`,
+      itemListElement: [
+        { "@type": "ListItem", position: 1, name: "Accueil", item: `${SITE}/` },
+        { "@type": "ListItem", position: 2, name: "Politique de confidentialité" },
+      ],
+    },
+  ],
+};
+
 export function meta({}: Route.MetaArgs) {
-  const url = "https://pierrebarbe.ca/politique-confidentialite";
-  const image = "https://pierrebarbe.ca/images/pb-og-image.jpg";
+  const image = `${SITE}/images/pb-og-image.jpg`;
 
   return [
-    { title: "Politique de confidentialité | Pierre Barbé" },
-
-    { name: "description", content: "Politique de confidentialité et protection des données personnelles. Durée de conservation, droits des utilisateurs." },
+    { title: "Politique de confidentialité | Pierre Barbé" },
+    {
+      name: "description",
+      content:
+        "Politique de confidentialité conforme à la Loi 25 du Québec : données collectées, conservation, transferts et droits des utilisateurs.",
+    },
     { name: "robots", content: "noindex, follow" },
-    { tagName: "link", rel: "canonical", href: url },
+    { tagName: "link", rel: "canonical", href: URL },
+    { property: "og:title", content: "Politique de confidentialité" },
     {
-      property: "og:title",
-      content: "Politique de confidentialité",
+      property: "og:description",
+      content:
+        "Politique de confidentialité conforme à la Loi 25 du Québec — collecte, conservation, droits.",
     },
-    {
-      property: "og:site_name",
-      content: "Pierre Barbé",
-    },
-    { property: "og:url", content: url },
+    { property: "og:site_name", content: "Pierre Barbé" },
+    { property: "og:locale", content: "fr_CA" },
+    { property: "og:url", content: URL },
     { property: "og:image", content: image },
     { property: "og:image:width", content: "1200" },
     { property: "og:image:height", content: "630" },
-    { property: "og:image:type", content: "image/avif" },
+    { property: "og:image:type", content: "image/jpeg" },
     { property: "og:type", content: "website" },
+    { name: "twitter:card", content: "summary_large_image" },
+    { name: "twitter:title", content: "Politique de confidentialité | Pierre Barbé" },
+    {
+      name: "twitter:description",
+      content: "Politique de confidentialité conforme à la Loi 25 du Québec.",
+    },
+    { name: "twitter:image", content: image },
   ];
 }
 
 export default function PrivacyPolicy() {
   return (
     <div>
+      <JsonLd data={privacySchema} />
+
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 pt-8">
         <Breadcrumbs
           items={[
@@ -42,63 +87,209 @@ export default function PrivacyPolicy() {
 
       <section className="mx-auto max-w-4xl px-6 py-12">
         <h1 className="text-3xl font-bold mb-6">Politique de confidentialité</h1>
-      <p className="mb-4 text-sm text-gray-500">
-        Dernière mise à jour : 3 juin 2025
-      </p>
+        <p className="mb-2 text-sm text-base-content/60">
+          Dernière mise à jour&nbsp;:{" "}
+          <time dateTime={DATE_MODIFIED}>16 avril 2026</time>
+        </p>
+        <p className="mb-6 text-sm text-base-content/60">
+          Date de prise d&apos;effet&nbsp;:{" "}
+          <time dateTime={DATE_PUBLISHED}>3 juin 2025</time>
+        </p>
 
-      <p className="mb-4">
-        Chez Pierre Barbé, développeur web freelance basé au Québec, la
-        protection de votre vie privée est une priorité. Cette politique
-        explique quelles données sont collectées, comment elles sont utilisées
-        et vos droits en tant qu’utilisateur.
-      </p>
+        <p className="mb-4">
+          Chez Pierre Barbé, développeur web freelance basé à Montréal (Québec),
+          la protection de ta vie privée est une priorité. La présente politique
+          est conforme à la{" "}
+          <strong>
+            Loi sur la protection des renseignements personnels dans le secteur
+            privé (Loi 25)
+          </strong>{" "}
+          du Québec. Elle explique quelles données sont collectées, comment
+          elles sont utilisées, où elles sont stockées et quels sont tes droits.
+        </p>
 
-      <h2 className="text-xl font-semibold mt-6 mb-2">📬 Données collectées</h2>
-      <p className="mb-4">
-        Les informations recueillies via le formulaire de contact sont : prénom,
-        nom de famille, adresse courriel et message. Aucune autre donnée n’est
-        collectée.
-      </p>
+        <h2 className="text-xl font-semibold mt-6 mb-2">
+          Responsable de la protection des renseignements personnels
+        </h2>
+        <p className="mb-4">
+          Conformément à l&apos;article&nbsp;3.1 de la Loi&nbsp;25, le
+          responsable désigné est&nbsp;:<br />
+          <strong>Pierre Barbé</strong>
+          <br />
+          <a
+            href="mailto:contact@pierrebarbe.ca"
+            className="text-primary underline"
+          >
+            contact@pierrebarbe.ca
+          </a>
+          <br />
+          Montréal, Québec (Canada)
+        </p>
 
-      <h2 className="text-xl font-semibold mt-6 mb-2">
-        🎯 Utilisation des données
-      </h2>
-      <p className="mb-4">
-        Les données sont utilisées uniquement pour répondre à votre demande.
-        Elles transitent par le service Resend et ne sont jamais revendues ni
-        partagées.
-      </p>
+        <h2 className="text-xl font-semibold mt-6 mb-2">Données collectées</h2>
+        <p className="mb-4">
+          Les informations recueillies via le formulaire de contact sont&nbsp;:
+          prénom, nom de famille, adresse courriel et message. Aucune autre
+          donnée n&apos;est collectée sur ce site.
+        </p>
 
-      <h2 className="text-xl font-semibold mt-6 mb-2">
-        🕓 Durée de conservation
-      </h2>
-      <p className="mb-4">
-        Les messages sont conservés durant 1 mois avant suppression définitive.
-      </p>
+        <h2 className="text-xl font-semibold mt-6 mb-2">Cookies et traceurs</h2>
+        <p className="mb-4">
+          Ce site <strong>n&apos;utilise pas de cookies de suivi</strong>,
+          d&apos;outils d&apos;analyse (Google Analytics, Meta Pixel, etc.) ni
+          de traceurs publicitaires. Seuls des cookies strictement techniques
+          peuvent être utilisés par l&apos;hébergeur pour le bon fonctionnement
+          du site.
+        </p>
 
-      <h2 className="text-xl font-semibold mt-6 mb-2">🔐 Sécurité</h2>
-      <p className="mb-4">
-        Les données sont protégées par des accès sécurisés (mot de passe, 2FA).
-      </p>
+        <h2 className="text-xl font-semibold mt-6 mb-2">
+          Utilisation des données
+        </h2>
+        <p className="mb-4">
+          Les données sont utilisées uniquement pour répondre à ta demande.
+          Elles ne sont ni revendues, ni partagées à des fins commerciales ou
+          publicitaires.
+        </p>
 
-      <h2 className="text-xl font-semibold mt-6 mb-2">
-        👤 Responsable des données
-      </h2>
-      <p className="mb-4">
-        Pierre Barbé –{" "}
-        <a
-          href="mailto:contact@pierrebarbe.ca"
-          className="text-primary underline"
-        >
-          contact@pierrebarbe.ca
-        </a>
-      </p>
+        <h2 className="text-xl font-semibold mt-6 mb-2">
+          Sous-traitants et transferts hors du Québec
+        </h2>
+        <p className="mb-4">
+          Pour assurer le fonctionnement du site et le traitement des messages,
+          les données peuvent transiter par les services suivants, pouvant
+          impliquer un transfert hors du Québec&nbsp;:
+        </p>
+        <ul className="mb-4 list-disc pl-6 space-y-2">
+          <li>
+            <strong>Vercel Inc.</strong> (hébergement, États-Unis) —{" "}
+            <a
+              href="https://vercel.com/legal/privacy-policy"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary underline"
+            >
+              politique de confidentialité Vercel
+            </a>
+          </li>
+          <li>
+            <strong>Resend</strong> (envoi de courriels transactionnels,
+            États-Unis) —{" "}
+            <a
+              href="https://resend.com/legal/privacy-policy"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary underline"
+            >
+              politique de confidentialité Resend
+            </a>
+          </li>
+        </ul>
+        <p className="mb-4">
+          Ces sous-traitants sont liés par des engagements contractuels assurant
+          un niveau de protection adéquat. Conformément à l&apos;article&nbsp;17
+          de la Loi&nbsp;25, une évaluation des facteurs relatifs à la vie
+          privée est réalisée pour tout transfert hors du Québec.
+        </p>
 
-      <h2 className="text-xl font-semibold mt-6 mb-2">🧾 Vos droits</h2>
-      <p className="mb-4">
-        Vous pouvez demander à consulter, modifier ou supprimer vos données à
-        tout moment, en écrivant à l'adresse ci-dessus.
-      </p>
+        <h2 className="text-xl font-semibold mt-6 mb-2">
+          Durée de conservation
+        </h2>
+        <p className="mb-4">
+          Les messages reçus via le formulaire de contact sont conservés
+          pendant&nbsp;12&nbsp;mois avant suppression définitive, sauf si une
+          relation contractuelle est établie (auquel cas la durée légale de
+          conservation comptable s&apos;applique).
+        </p>
+
+        <h2 className="text-xl font-semibold mt-6 mb-2">Sécurité</h2>
+        <p className="mb-4">
+          Les données sont protégées par des accès sécurisés (mots de passe
+          forts, authentification à deux facteurs), un chiffrement en transit
+          (HTTPS/TLS) et des sauvegardes régulières chez les hébergeurs.
+        </p>
+
+        <h2 className="text-xl font-semibold mt-6 mb-2">
+          Tes droits (Loi&nbsp;25)
+        </h2>
+        <p className="mb-4">
+          En vertu de la Loi&nbsp;25, tu disposes des droits suivants sur tes
+          renseignements personnels&nbsp;:
+        </p>
+        <ul className="mb-4 list-disc pl-6 space-y-2">
+          <li>
+            <strong>Droit d&apos;accès</strong>&nbsp;: obtenir une copie des
+            données te concernant (art.&nbsp;27)
+          </li>
+          <li>
+            <strong>Droit de rectification</strong>&nbsp;: corriger des données
+            inexactes, incomplètes ou équivoques (art.&nbsp;28)
+          </li>
+          <li>
+            <strong>Droit à la portabilité</strong>&nbsp;: recevoir tes données
+            dans un format technologique structuré et couramment utilisé
+            (art.&nbsp;27)
+          </li>
+          <li>
+            <strong>Droit à la désindexation</strong>&nbsp;: demander la
+            cessation de la diffusion ou le déréférencement d&apos;un lien
+            (art.&nbsp;28.1)
+          </li>
+          <li>
+            <strong>Droit au retrait du consentement</strong> à tout moment
+          </li>
+          <li>
+            <strong>Droit d&apos;effacement</strong>&nbsp;: demander la
+            suppression de tes données
+          </li>
+        </ul>
+        <p className="mb-4">
+          Pour exercer ces droits, écris à{" "}
+          <a
+            href="mailto:contact@pierrebarbe.ca"
+            className="text-primary underline"
+          >
+            contact@pierrebarbe.ca
+          </a>
+          . Une réponse te sera fournie dans les 30&nbsp;jours.
+        </p>
+
+        <h2 className="text-xl font-semibold mt-6 mb-2">
+          Décision automatisée
+        </h2>
+        <p className="mb-4">
+          Aucune décision te concernant n&apos;est prise sur la base d&apos;un
+          traitement automatisé de tes renseignements personnels.
+        </p>
+
+        <h2 className="text-xl font-semibold mt-6 mb-2">
+          Recours auprès de la Commission d&apos;accès à l&apos;information
+        </h2>
+        <p className="mb-4">
+          Si tu estimes que tes droits ne sont pas respectés, tu peux déposer
+          une plainte auprès de la Commission d&apos;accès à l&apos;information
+          du Québec (CAI)&nbsp;:<br />
+          <a
+            href="https://www.cai.gouv.qc.ca/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary underline"
+          >
+            www.cai.gouv.qc.ca
+          </a>
+        </p>
+
+        <h2 className="text-xl font-semibold mt-6 mb-2">
+          Modifications de la politique
+        </h2>
+        <p className="mb-4">
+          Cette politique peut être mise à jour pour refléter des changements
+          légaux ou techniques. La date de dernière mise à jour est indiquée en
+          haut de la page. Pour les autres informations légales, consulte les{" "}
+          <a href="/mentions-legales" className="text-primary underline">
+            mentions légales
+          </a>
+          .
+        </p>
       </section>
     </div>
   );


### PR DESCRIPTION
- /contact: full LocalBusiness schema, H1 with Montréal keywords, zones servies, remove Calendly
- /mentions-legales: add WebPage/BreadcrumbList schema, Québec jurisdiction, Lucide attribution
- /politique-confidentialite: Loi 25 compliance (RPRP art. 3.1, transferts USA, droits art. 27/28/28.1, recours CAI)
- contact-card: replace Calendly link with /contact redirect
- Fix og:image:type avif→jpeg, wrap dates in <time> tags