### PR TITLE
fix(seo): remove duplicate twitter meta tags (card/creator/site)

### DIFF
--- a/app/routes/contact.tsx
+++ b/app/routes/contact.tsx
@@ -132,7 +132,6 @@ export function meta({}: Route.MetaArgs) {
     { property: "og:type", content: "website" },
     { property: "og:site_name", content: "Pierre Barbé" },
     { property: "og:locale", content: "fr_CA" },
-    { name: "twitter:card", content: "summary_large_image" },
     { name: "twitter:title", content: "Contact & devis site web à Montréal — Pierre Barbé" },
     {
       name: "twitter:description",

--- a/app/routes/legal-notice.tsx
+++ b/app/routes/legal-notice.tsx
@@ -61,7 +61,6 @@ export function meta({}: Route.MetaArgs) {
     { property: "og:image:height", content: "630" },
     { property: "og:image:type", content: "image/jpeg" },
     { property: "og:type", content: "website" },
-    { name: "twitter:card", content: "summary_large_image" },
     { name: "twitter:title", content: "Mentions légales | Pierre Barbé" },
     {
       name: "twitter:description",

--- a/app/routes/privacy-policy.tsx
+++ b/app/routes/privacy-policy.tsx
@@ -61,7 +61,6 @@ export function meta({}: Route.MetaArgs) {
     { property: "og:image:height", content: "630" },
     { property: "og:image:type", content: "image/jpeg" },
     { property: "og:type", content: "website" },
-    { name: "twitter:card", content: "summary_large_image" },
     { name: "twitter:title", content: "Politique de confidentialité | Pierre Barbé" },
     {
       name: "twitter:description",

--- a/app/routes/projects/projects.$slug.tsx
+++ b/app/routes/projects/projects.$slug.tsx
@@ -53,7 +53,6 @@ export function meta({ data }: Route.MetaArgs) {
     { property: "og:image:height", content: "630" },
     { property: "og:type", content: "article" },
     { property: "og:locale", content: "fr_CA" },
-    { name: "twitter:card", content: "summary_large_image" },
     { name: "twitter:title", content: study.metaTitle },
     { name: "twitter:description", content: study.metaDescription },
     { name: "twitter:image", content: image },

--- a/app/utils/seo.ts
+++ b/app/utils/seo.ts
@@ -46,13 +46,10 @@ export function generateSEOMeta({
     { property: "og:site_name", content: "Pierre Barbé" },
     { property: "og:locale", content: "fr_CA" },
 
-    // Twitter
-    { name: "twitter:card", content: "summary_large_image" },
+    // Twitter (card/creator/site set globally in root.tsx)
     { name: "twitter:title", content: title },
     { name: "twitter:description", content: description },
     { name: "twitter:image", content: image },
-    { name: "twitter:creator", content: "@PierreBarbe" },
-    { name: "twitter:site", content: "@PierreBarbe" },
   ];
 }
 


### PR DESCRIPTION
These are already set globally in root.tsx — redeclaring them per-page triggered duplicate_meta_tags warnings on /contact (1), /services (3), and other pages. Restores on-page score to 100.